### PR TITLE
Add block order and argument description format checks

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -57,24 +57,15 @@ class ConventionChecker:
     """
     _RE_ARGSTART = re(r"(^ {8})(\**[\w\[\]_]{1,}?)\s*?:(.{2,})?", IGNORECASE)
 
-    SECTIONS_WITH_ARGS = [
-        'Args',
-        'Arguments',
-        'Raises'
-    ]
+    SECTIONS_WITH_ARGS = ['Args', 'Raises']
 
     BLOCK_ORDER = [
         'Example',
-        'Examples',
         'Args',
-        'Arguments',
-        'Return',
         'Returns',
-        'Yield',
         'Yields',
         'Raises',
         'Note',
-        'Notes'
     ]
 
     NUMPY_SECTION_NAMES = (

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -6,6 +6,7 @@ import tokenize as tk
 from collections import namedtuple
 from itertools import chain, takewhile
 from re import compile as re
+from re import IGNORECASE
 from textwrap import dedent
 
 from . import violations
@@ -54,6 +55,27 @@ class ConventionChecker:
     D40x: Docstring content issues
 
     """
+    _RE_ARGSTART = re(r"(^ {8})(\**[\w\[\]_]{1,}?)\s*?:(.{2,})?", IGNORECASE)
+
+    SECTIONS_WITH_ARGS = [
+        'Args',
+        'Arguments',
+        'Raises'
+    ]
+
+    BLOCK_ORDER = [
+        'Example',
+        'Examples',
+        'Args',
+        'Arguments',
+        'Return',
+        'Returns',
+        'Yield',
+        'Yields',
+        'Raises',
+        'Note',
+        'Notes'
+    ]
 
     NUMPY_SECTION_NAMES = (
         'Short Summary',
@@ -434,7 +456,6 @@ class ConventionChecker:
                 'ur"""',
                 "ur'''",
             ]
-
             lines = ast.literal_eval(docstring).split('\n')
             if len(lines) > 1:
                 first = docstring.split("\n")[0].strip().lower()
@@ -658,7 +679,7 @@ class ConventionChecker:
             context.line.strip().lstrip(context.section_name.strip()).strip()
         )
 
-        section_suffix_is_only_colon = section_name_suffix == ':'
+        section_suffix_starts_with = section_name_suffix.startswith(':')
 
         punctuation = [',', ';', '.', '-', '\\', '/', ']', '}', ')']
         prev_line_ends_with_punctuation = any(
@@ -666,7 +687,7 @@ class ConventionChecker:
         )
 
         this_line_looks_like_a_section_name = (
-            is_blank(section_name_suffix) or section_suffix_is_only_colon
+            is_blank(section_name_suffix) or section_suffix_starts_with
         )
 
         prev_line_looks_like_end_of_paragraph = (
@@ -747,6 +768,16 @@ class ConventionChecker:
                 yield violations.D414(section_name)
 
     @classmethod
+    def _check_args_description_starts_with_new_line(cls, context):
+        for line in context.following_lines:
+            if not cls._RE_ARGSTART.match(line):
+                continue
+
+            argument_description = cls._RE_ARGSTART.match(line).group()
+            if argument_description.endswith(":"):
+                yield violations.D421(argument_description[:-1].strip(), context.section_name)
+
+    @classmethod
     def _check_common_section(
         cls, docstring, definition, context, valid_section_names
     ):
@@ -762,6 +793,9 @@ class ConventionChecker:
         """
         indentation = cls._get_docstring_indent(definition, docstring)
         capitalized_section = context.section_name.title()
+
+        if context.section_name in cls.SECTIONS_WITH_ARGS:
+            yield from cls._check_args_description_starts_with_new_line(context)
 
         if (
             context.section_name not in valid_section_names
@@ -992,8 +1026,9 @@ class ConventionChecker:
                 for arg_name in function_args
                 if not is_def_arg_private(arg_name)
             ]
+
             missing_args = set(function_args) - docstring_args
-            if missing_args:
+            if missing_args or (function_args and not docstring_args):
                 yield violations.D417(
                     ", ".join(sorted(missing_args)), definition.name
                 )
@@ -1020,9 +1055,6 @@ class ConventionChecker:
             yield violations.D416(
                 capitalized_section + ":", context.line.strip()
             )
-
-        if capitalized_section in ("Args", "Arguments"):
-            yield from cls._check_args_section(docstring, definition, context)
 
     @staticmethod
     def _get_section_contexts(lines, valid_section_names):
@@ -1139,10 +1171,27 @@ class ConventionChecker:
         Yields all violation from `_check_google_section` for each valid
         Google-style section.
         """
+
+        args_section_found = 0
+        found_blocks = []
         for ctx in self._get_section_contexts(
             lines, self.GOOGLE_SECTION_NAMES
         ):
+            found_blocks.append(ctx.section_name)
+
+            if ctx.section_name in ['Args', 'Arguments']:
+                args_section_found = 1
+                yield from self._check_args_section(docstring, definition, ctx)
+
             yield from self._check_google_section(docstring, definition, ctx)
+
+        if not args_section_found:
+            yield from ConventionChecker._check_missing_args(set(), definition)
+
+        if found_blocks:
+            current_blocks_order = [block for block in self.BLOCK_ORDER if block in found_blocks]
+            if found_blocks != current_blocks_order:
+                yield violations.D420(definition.name)
 
     @check_for(Definition)
     def check_docstring_sections(self, definition, docstring):
@@ -1152,16 +1201,6 @@ class ConventionChecker:
 
         lines = docstring.split("\n")
         if len(lines) < 2:
-            return
-
-        found_numpy = yield from self._check_numpy_sections(
-            lines, definition, docstring
-        )
-        if found_numpy:
-            return
-
-        found_sphinx = yield from self._check_sphinx_params(lines, definition)
-        if found_sphinx:
             return
 
         yield from self._check_google_sections(lines, definition, docstring)

--- a/src/pydocstyle/violations.py
+++ b/src/pydocstyle/violations.py
@@ -419,6 +419,15 @@ D419 = D4xx.create_error(
     'D419',
     'Docstring is empty',
 )
+D420 = D4xx.create_error(
+    'D420',
+    'Docstring blocks are not in correct order.',
+)
+D421 = D4xx.create_error(
+    'D421',
+    'Description for argument / raise starts on a new line or is missing.',
+    'argument / raise: {0!r}, in {1!r}',
+)
 
 
 class AttrDict(dict):


### PR DESCRIPTION
1. Add block order check, we always want to the following order: Example -> Args ->  Returns -> Raises -> Note. Any of them can be missing and we don't raise an error for that.
2. Add argument / raise description check. We don't allow the description of an argument to start from new line.
3. Yield error for missing args description if Args: block is not defined and function has parameters.
4. Fix to always check google style sections